### PR TITLE
Autoload xref-js2-xref-backend

### DIFF
--- a/xref-js2.el
+++ b/xref-js2.el
@@ -76,6 +76,7 @@ In each regexp string, '%s' is expanded with the searched symbol."
   :type 'list
   :group 'xref-js2)
 
+;;;###autoload
 (defun xref-js2-xref-backend ()
   "Xref-Js2 backend for Xref."
   'xref-js2)


### PR DESCRIPTION
This allows the setup instructions to work without needing to load xref-j2 first.
