### PR TITLE
Add regexp for es6 function definition

### DIFF
--- a/xref-js2.el
+++ b/xref-js2.el
@@ -66,7 +66,8 @@
 
 (defcustom xref-js2-definitions-regexps '("\\b%s\\b[\\s]*[:=][^=]"
                                           "function[\\s]+\\b%s\\b"
-                                          "[^.]%s[\\s]*\\(")
+                                          "class[\\s]+\\b%s\\b"
+                                          "(?<!new)[^.]%s[\\s]*\\(")
   "List of regular expressions that match definitions of a symbol.
 In each regexp string, '%s' is expanded with the searched symbol."
   :type 'list

--- a/xref-js2.el
+++ b/xref-js2.el
@@ -65,7 +65,8 @@
 
 
 (defcustom xref-js2-definitions-regexps '("\\b%s\\b[\\s]*[:=][^=]"
-                                          "function[\\s]+\\b%s\\b")
+                                          "function[\\s]+\\b%s\\b"
+                                          "[^.]%s[\\s]*\\(")
   "List of regular expressions that match definitions of a symbol.
 In each regexp string, '%s' is expanded with the searched symbol."
   :type 'list


### PR DESCRIPTION
It's possible to declare methods like this:
```js
const foo = {
    bar() {}
}
```
Currently `xref-js2` can't find such definition.