### PR TITLE
add rg support and ensure line number order in xref buffer.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,22 +20,34 @@ pass on result candidates and eliminates possible false positives using
 
 - Emacs 25.1
 - `ag` (the [silver searcher](http://geoff.greer.fm/ag/))
+  - or `rg` ([ripgrep](https://github.com/BurntSushi/ripgrep))
 - js2-mode
 
 ## Installation
 
 If you use `js2-mode`, `M-.` will be bound by `js2`, you might want to unbind it:
 
-```
+```elisp
 (define-key js2-mode-map (kbd "M-.") nil)
 ```
 
 Then you need to add the xref backend:
 
-```
+```elisp
 (add-hook 'js2-mode-hook (lambda ()
   (add-hook 'xref-backend-functions #'xref-js2-xref-backend nil t)))
 ```
+
+## Customisations
+By default, `xref-js2` will use `ag` for search operations, to switch to using `rg` put the following into your config file and ensure the ripgrep executeable is visible from your **PATH** environment variable:
+
+```elisp
+(setq xref-js2-search-program 'rg)
+```
+
+If you have issues with `xref-js2` using `rg` not searching certain files, ensure the extension of those files is included in `xref-js2-js-extensions`.
+
+You can further customize the execution of `ag` or `rg` by `xref-js2` by changing `xref-js2-ag-arguments` & `xref-js2-rg-arguments` respectively. Though take care when doing so, many of these are used to produce an output which `xref-js2` can understand.
 
 ## Keybindings
 

--- a/xref-js2.el
+++ b/xref-js2.el
@@ -186,8 +186,8 @@ concatenated together into one regexp, expanding occurrences of
                                      (funcall (cdr search-tuple) regexp))))
         (apply #'process-file (executable-find search-program) nil t nil search-args))
 
-      (goto-char (point-min))
-      (while (re-search-forward "^\\(.+\\)$" nil t)
+      (goto-char (point-max)) ;; NOTE maybe redundant
+      (while (re-search-backward "^\\(.+\\)$" nil t)
         (push (match-string-no-properties 1) matches)))
     (seq-remove #'xref-js2--false-positive
                 (seq-map (lambda (match)


### PR DESCRIPTION
This pull request addresses issues [12](https://github.com/NicolasPetton/xref-js2/issues/12) and [16](https://github.com/NicolasPetton/xref-js2/issues/16)

the default search procedure is still ag. If you want to use rg
include `(setq xref-js2-search-program 'rg)` in your config file
or set `xref-js2-search-program` to `'rg` via the customize menu.

with xref-js2, ripgrep is configured to duplicate the operation
of ag. search queries are case insensitive by default. you can
customize the arguments passed to rg by setting `xref-js2-rg-arguments`
to your desired values. filtering based on file extensions is also
implemented, but unlike ag's built in '--js' flag, you must manually
specify conforming extensions (or really just any valid suffix) in
`xref-js2-js-extensions`.

NOTE: `xref-js2-ignored-dirs` & `xref-js2-ignored-files` have been
      kept with their initial ag compatible values and work is done
      at runtime to make them compatible with ripgrep. If you wish
      to add more values to these variables, use ag compatible values.