### PR TITLE
Avoid compilation error

### DIFF
--- a/xref-js2.el
+++ b/xref-js2.el
@@ -126,7 +126,7 @@ which is really sub optimal."
         (widen)
         (goto-char (point-min))
         (while (re-search-forward "\\w+" nil t)
-          (add-to-list 'words (match-string-no-properties 0)))
+          (push  (match-string-no-properties 0) words))
         (seq-uniq words)))))
 
 (defun xref-js2--xref-find-references (symbol)


### PR DESCRIPTION
The compiler complains:

  Error: ‘add-to-list’ can’t use lexical var ‘words’; use ‘push’ or
  ‘cl-pushnew’

* xref-js2.el (xref-backend-identifier-completion-table): Replace
`add-to-list' with `push'.